### PR TITLE
忽略build结果文件夹

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+_book


### PR DESCRIPTION
* 在本地用gitbook build后，_book文件夹容易错误入库，建议ignore
* test pull request 
