### PR TITLE
一处翻译错误 modified:   doc/handbook/Basic Types.md

### DIFF
--- a/doc/handbook/Basic Types.md
+++ b/doc/handbook/Basic Types.md
@@ -135,7 +135,7 @@ let c: Color = Color.Green;
 enum Color {Red = 1, Green, Blue}
 let colorName: string = Color[2];
 
-alert(colorName);  // 显示'Green'因数它的值大于2
+alert(colorName);  // 显示'Green'因为上面代码里它的值是2
 ```
 
 # 任意值


### PR DESCRIPTION
原文

> Displays 'Green' as it's value is 2 above

翻译错误